### PR TITLE
Convert datetime to string before diffing in UI

### DIFF
--- a/pygeoapi_config_dialog.py
+++ b/pygeoapi_config_dialog.py
@@ -277,8 +277,8 @@ class PygeoapiConfigDialog(QtWidgets.QDialog, FORM_CLASS):
             return True
 
         diff_data = diff_yaml_dict(
-            self.yaml_original_data,
-            self.config_data.asdict_enum_safe(self.config_data),
+            self.config_data.asdict_enum_safe(deepcopy(self.yaml_original_data), True),
+            self.config_data.asdict_enum_safe(deepcopy(self.config_data), True),
         )
 
         if (


### PR DESCRIPTION
Already done in tests, now repeating in the UI: before making DIFF, make a deepcopy of both data versions (opened vs modified), and convert datetime objects to strings of a specified format. Without it, diff shows the same data as 'changed' objects, because one is 'text' and another is 'datetime'