### PR TITLE
Prevent automatic workflow triggers by fork PRs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,6 +8,7 @@ on:
       - master
 jobs:
   test-on-pr: 
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Implemented this elsewhere to protect Actions credits, and remembered about this repo.