### PR TITLE
Update validator of bbox to accept doubles

### DIFF
--- a/ui_widgets/UiSetter.py
+++ b/ui_widgets/UiSetter.py
@@ -33,7 +33,7 @@ from .ui_setter_utils import (
 from .utils import get_widget_text_value, reset_widget
 
 
-from PyQt5.QtGui import QIntValidator
+from PyQt5.QtGui import QIntValidator, QDoubleValidator
 from PyQt5.QtCore import (
     Qt,
 )
@@ -555,10 +555,10 @@ class UiSetter:
 
         # set validators for some fields
         # resource bbox
-        self.dialog.lineEditResExtentsSpatialXMin.setValidator(QIntValidator())
-        self.dialog.lineEditResExtentsSpatialYMin.setValidator(QIntValidator())
-        self.dialog.lineEditResExtentsSpatialXMax.setValidator(QIntValidator())
-        self.dialog.lineEditResExtentsSpatialYMax.setValidator(QIntValidator())
+        self.dialog.lineEditResExtentsSpatialXMin.setValidator(QDoubleValidator())
+        self.dialog.lineEditResExtentsSpatialYMin.setValidator(QDoubleValidator())
+        self.dialog.lineEditResExtentsSpatialXMax.setValidator(QDoubleValidator())
+        self.dialog.lineEditResExtentsSpatialYMax.setValidator(QDoubleValidator())
         # regex_bbox = QRegularExpression(r"-?\d+(\.\d+)?,-?\d+(\.\d+)?,-?\d+(\.\d+)?,-?\d+(\.\d+)?")
         # validator_bbox = QRegularExpressionValidator(regex_bbox)
         # self.dialog.lineEditResExtentsSpatialBbox.setValidator(validator_bbox)


### PR DESCRIPTION
Currently the validator of bbox coordinates is forcing all values to be integers. However, we may have double values for coordinates.

```
        bbox:
        - -10.1934
        - 36.7643
        - -5.70954
        - 42.2796
```